### PR TITLE
feat: add Cmd+K search palette for posts, projects and pages

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -6,6 +6,16 @@
   "nav_projects": "projects",
   "nav_blog": "blog",
   "nav_notes": "notes",
+  "nav_contact": "contact",
+  "nav_search": "search",
+
+  "search_title": "Search",
+  "search_placeholder": "Search posts, projects, pages…",
+  "search_no_results": "No results for",
+  "search_group_pages": "Pages",
+  "search_group_posts": "Posts",
+  "search_group_projects": "Projects",
+  "search_hint": "↑↓ navigate · ↵ open · esc close",
 
   "home_title": "Hi, I'm Rafael Passoca.",
   "home_intro": "As a developer, I love to automate things and make them work for me. I also believe that appearance and practicality are the best influences to the user. This is what matters. And I love to make it happen.",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -6,6 +6,16 @@
   "nav_projects": "projetos",
   "nav_blog": "blog",
   "nav_notes": "notas",
+  "nav_contact": "contato",
+  "nav_search": "buscar",
+
+  "search_title": "Buscar",
+  "search_placeholder": "Busque posts, projetos, páginas…",
+  "search_no_results": "Nenhum resultado para",
+  "search_group_pages": "Páginas",
+  "search_group_posts": "Posts",
+  "search_group_projects": "Projetos",
+  "search_hint": "↑↓ navegar · ↵ abrir · esc fechar",
 
   "home_title": "Oi, eu sou o Rafael Passoca.",
   "home_intro": "Como dev, eu adoro automatizar coisas e fazer elas trabalharem pra mim. Também acredito que aparência e praticidade são as melhores influências pra experiência do usuário. Isso é o que importa. E eu adoro fazer acontecer.",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "concurrently": "^6.4.0",
     "cross-env": "^7.0.3",
     "dssoca": "^0.9.0",
+    "minisearch": "^7.2.0",
     "photoswipe": "^5.4.3",
     "sass": "^1.43.5"
   },

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -8,7 +8,10 @@
   import { Menu, Spinner, Topbar } from "dssoca";
   import { locales, localizeHref } from "$lib/paraglide/runtime";
   import { m } from "$lib/paraglide/messages";
+  import { openSearch } from "$lib/stores/search.store";
   let animation = false;
+  // Render no shortcut hint until mounted so SSR never guesses the platform
+  let shortcut: string | null = null;
 
   const themes: { id: Theme; label: string; themeColor?: string }[] = [
     { id: "dark", label: "Dark", themeColor: "#0b1220" },
@@ -22,6 +25,7 @@
     if (!browser) return;
     const localTheme = localStorage.getItem("theme") as Theme | null;
     if (localTheme && themes.some((t) => t.id === localTheme)) theme.set(localTheme);
+    shortcut = /mac/i.test(navigator.platform) ? "⌘K" : "Ctrl K";
   });
 
   $: current = themes.find((t) => t.id === $theme);
@@ -123,6 +127,22 @@
 
   {#snippet userMenu()}
     <div class="icons">
+      <button
+        class="search-button"
+        on:click={openSearch}
+        aria-label={m.search_title()}
+        aria-keyshortcuts="Control+K Meta+K"
+      >
+        <SVG
+          name="search"
+          width="22"
+          height="22"
+          fill='var(--app-color-text)'
+        />
+        {#if shortcut}
+          <kbd>{shortcut}</kbd>
+        {/if}
+      </button>
       <a href="/github" target="_blank" aria-label="GitHub">
         <SVG
           name="github"
@@ -163,6 +183,23 @@
   display: flex
   align-items: center
   gap: 8px
+
+.search-button
+  display: flex
+  align-items: center
+  gap: 6px
+  padding: 0
+  background: none
+  border: none
+  color: var(--app-color-text)
+  cursor: pointer
+  kbd
+    padding: 2px 5px
+    border: 1px solid var(--ss-line-strong)
+    font-family: var(--ss-font-mono)
+    font-size: 11px
+    line-height: 12px
+    color: var(--ss-fg-muted)
 
 .flag
   font-size: 14px

--- a/src/lib/components/SearchPalette.svelte
+++ b/src/lib/components/SearchPalette.svelte
@@ -1,0 +1,329 @@
+<script lang="ts">
+  import { tick } from "svelte";
+  import { afterNavigate } from "$app/navigation";
+  import { getLocale, localizeHref } from "$lib/paraglide/runtime";
+  import { m } from "$lib/paraglide/messages";
+  import { searchOpen, closeSearch, toggleSearch } from "$lib/stores/search.store";
+  import type { SearchApi, SearchDocType, SearchResult } from "$lib/search";
+  import type { Locale } from "$lib/posts";
+
+  type Item = Omit<SearchResult, "snippet"> & Partial<Pick<SearchResult, "snippet">>;
+
+  let inputEl: HTMLInputElement | null = null;
+  let listEl: HTMLElement | null = null;
+  let engine: SearchApi | null = null;
+  let loading = false;
+  let query = "";
+  let selected = 0;
+  let previousFocus: HTMLElement | null = null;
+
+  // The engine (minisearch + all post bodies) only loads on first open.
+  async function loadEngine() {
+    if (engine || loading) return;
+    loading = true;
+    try {
+      const mod = await import("$lib/search");
+      engine = mod.getSearch(getLocale() as Locale);
+    } finally {
+      loading = false;
+    }
+  }
+
+  let wasOpen = false;
+  $: syncOpenState($searchOpen);
+  function syncOpenState(open: boolean) {
+    if (open && !wasOpen) {
+      wasOpen = true;
+      onOpen();
+    } else if (!open && wasOpen) {
+      wasOpen = false;
+      onClose();
+    }
+  }
+
+  async function onOpen() {
+    previousFocus = document.activeElement as HTMLElement | null;
+    document.body.style.overflow = "hidden";
+    await tick();
+    inputEl?.focus();
+    loadEngine();
+  }
+
+  // Single close path for Esc / backdrop / Enter / link click / navigation.
+  function onClose() {
+    document.body.style.overflow = "";
+    query = "";
+    selected = 0;
+    previousFocus?.focus?.();
+    previousFocus = null;
+  }
+
+  afterNavigate(() => {
+    if ($searchOpen) closeSearch();
+  });
+
+  function onWindowKeydown(e: KeyboardEvent) {
+    if (e.isComposing) return;
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+      // Ctrl+K is the browser's address-bar/search shortcut
+      e.preventDefault();
+      toggleSearch();
+      return;
+    }
+    if ($searchOpen && e.key === "Escape") {
+      e.preventDefault();
+      closeSearch();
+    }
+  }
+
+  function onInputKeydown(e: KeyboardEvent) {
+    if (e.isComposing) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      move(1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      move(-1);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const item = items[selected];
+      if (item) {
+        // Real navigation via the option's <a>, so SvelteKit handles it the
+        // same way for Enter and click; afterNavigate closes the palette.
+        optionAnchor(selected)?.click();
+      }
+    } else if (e.key === "Tab") {
+      // Focus stays on the input while the palette is open
+      e.preventDefault();
+    }
+  }
+
+  function optionAnchor(index: number): HTMLAnchorElement | null {
+    return listEl?.querySelector(`#search-option-${index} a`) ?? null;
+  }
+
+  async function move(delta: number) {
+    if (!items.length) return;
+    selected = (selected + delta + items.length) % items.length;
+    await tick();
+    listEl
+      ?.querySelector(`#search-option-${selected}`)
+      ?.scrollIntoView({ block: "nearest" });
+  }
+
+  $: results = engine && query.trim() ? engine.query(query) : [];
+  $: quickJumps = engine
+    ? engine.pages.map(
+        (p): Item => ({ id: p.id, type: p.type, title: p.title, href: p.href })
+      )
+    : [];
+  $: items = (query.trim() ? results : quickJumps) as Item[];
+  $: groups = groupItems(items);
+
+  const groupOrder: SearchDocType[] = ["page", "post", "project"];
+  $: groupLabels = {
+    page: m.search_group_pages(),
+    post: m.search_group_posts(),
+    project: m.search_group_projects(),
+  } as Record<SearchDocType, string>;
+
+  // Items arrive already grouped page → post → project, so per-type grouping
+  // preserves the flat order used by keyboard selection.
+  function groupItems(list: Item[]) {
+    let index = 0;
+    return groupOrder
+      .map((type) => ({
+        type,
+        items: list.filter((i) => i.type === type).map((item) => ({ item, index: index++ })),
+      }))
+      .filter((g) => g.items.length);
+  }
+
+  function onQueryInput() {
+    selected = 0;
+  }
+</script>
+
+<svelte:window on:keydown={onWindowKeydown} />
+
+{#if $searchOpen}
+  <div class="overlay">
+    <button
+      class="backdrop"
+      tabindex="-1"
+      aria-label={m.search_title()}
+      on:click={() => closeSearch()}
+    ></button>
+    <div class="panel" role="dialog" aria-modal="true" aria-label={m.search_title()}>
+      <input
+        bind:this={inputEl}
+        bind:value={query}
+        on:input={onQueryInput}
+        on:keydown={onInputKeydown}
+        type="text"
+        placeholder={m.search_placeholder()}
+        spellcheck="false"
+        autocomplete="off"
+        role="combobox"
+        aria-expanded={items.length > 0}
+        aria-controls="search-listbox"
+        aria-activedescendant={items.length ? `search-option-${selected}` : undefined}
+      />
+
+      <div class="results" bind:this={listEl}>
+        {#if loading && !engine}
+          <p class="state">…</p>
+        {:else if query.trim() && !items.length}
+          <p class="state">{m.search_no_results()} “{query.trim()}”</p>
+        {:else}
+          <ul id="search-listbox" role="listbox" aria-label={m.search_title()}>
+            {#each groups as group (group.type)}
+              <li class="group" role="presentation">
+                <span class="group-label">{groupLabels[group.type]}</span>
+                <ul role="presentation">
+                  {#each group.items as { item, index } (item.id)}
+                    <li
+                      id="search-option-{index}"
+                      role="option"
+                      aria-selected={index === selected}
+                    >
+                      <a
+                        href={localizeHref(item.href)}
+                        class:selected={index === selected}
+                        tabindex="-1"
+                        on:mousemove={() => (selected = index)}
+                        on:click={() => closeSearch()}
+                      >
+                        <span class="title">{item.title}</span>
+                        {#if item.snippet?.length}
+                          <span class="snippet">
+                            {#each item.snippet as part, i (i)}{#if part.hit}<mark
+                                >{part.text}</mark
+                              >{:else}{part.text}{/if}{/each}
+                          </span>
+                        {/if}
+                      </a>
+                    </li>
+                  {/each}
+                </ul>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+
+      <footer>{m.search_hint()}</footer>
+    </div>
+  </div>
+{/if}
+
+<style lang="sass">
+.overlay
+  position: fixed
+  inset: 0
+  // above dssoca Topbar (10/20), BottomNav (30) and Menu (50)
+  z-index: 100
+  font-family: var(--ss-font-mono)
+
+.backdrop
+  position: absolute
+  inset: 0
+  width: 100%
+  height: 100%
+  background: rgba(0, 0, 0, 0.6)
+  border: none
+  padding: 0
+  cursor: default
+
+.panel
+  position: relative
+  margin: 15vh auto 0
+  width: min(640px, calc(100vw - 32px))
+  display: flex
+  flex-direction: column
+  background: var(--ss-bg-elev)
+  border: 1px solid var(--ss-line-strong)
+  border-radius: 0
+
+input
+  width: 100%
+  padding: 14px 16px
+  background: transparent
+  border: none
+  border-bottom: 1px solid var(--ss-line)
+  color: var(--ss-fg)
+  font-family: inherit
+  font-size: 15px
+  &:focus
+    outline: none
+    border-bottom-color: var(--ss-primary)
+  &::placeholder
+    color: var(--ss-fg-muted)
+
+.results
+  overflow-y: auto
+  max-height: 60vh
+  overscroll-behavior: contain
+
+ul
+  list-style: none
+  margin: 0
+  padding: 0
+
+.state
+  padding: 16px
+  font-size: 13px
+  color: var(--ss-fg-muted)
+
+.group-label
+  display: block
+  padding: 10px 16px 4px
+  font-size: 11px
+  text-transform: uppercase
+  letter-spacing: 0.08em
+  color: var(--ss-fg-muted)
+
+a
+  display: block
+  padding: 8px 16px 8px 14px
+  border-left: 2px solid transparent
+  color: var(--ss-fg)
+  text-decoration: none
+  &.selected
+    background: var(--ss-primary-soft)
+    border-left-color: var(--ss-primary)
+
+.title
+  display: block
+  font-size: 14px
+  line-height: 20px
+
+.snippet
+  display: block
+  margin-top: 2px
+  font-size: 12px
+  line-height: 16px
+  color: var(--ss-fg-muted)
+  white-space: nowrap
+  overflow: hidden
+  text-overflow: ellipsis
+  mark
+    background: var(--ss-primary-soft)
+    color: var(--ss-primary)
+
+footer
+  padding: 8px 16px
+  border-top: 1px solid var(--ss-line)
+  font-size: 11px
+  color: var(--ss-fg-muted)
+
+@media (max-width: 767px)
+  .panel
+    margin: 0
+    width: 100vw
+    // dvh: keep the input visible when the mobile keyboard opens
+    height: 100dvh
+  .results
+    flex: 1
+    max-height: none
+</style>

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -1,0 +1,42 @@
+// Project cards shown on /projects, also indexed by the search palette.
+export type Project = {
+  name: string;
+  description: string;
+  features: string[];
+  imageSrc?: string;
+  imageAlt?: string;
+  githubUrl?: string;
+  websiteUrl?: string;
+};
+
+export const projects: Project[] = [
+  {
+    name: "dssoca",
+    description:
+      "My own Svelte 5 design system — signal green on near-black, monospace-forward, zero border-radius. It powers this very website.",
+    features: [
+      "Two orthogonal axes: color (dark/light) and size (sm/md/lg)",
+      "Token-driven CSS custom properties — flip an axis on any ancestor and everything rescales",
+      "Tokens-only import for apps that own their global styles",
+      "Published on npm with CI and full docs",
+    ],
+    githubUrl: "https://github.com/httpassoca/dssoca",
+    websiteUrl: "https://dssoca.passoca.dev",
+  },
+  {
+    name: "Bloodborne Sudoku",
+    description:
+      "A Bloodborne-themed Sudoku with a custom UI and game feel — built to be playable and polished on mobile. AI btw.",
+    features: [
+      "Multiple difficulties + new puzzle generation",
+      "Notes/pencil marks + error highlighting",
+      "Keyboard support (desktop) + touch-first controls (mobile)",
+      "Bloodborne-inspired theme, typography and sound design",
+      "Multiplayer coop and duel modes",
+    ],
+    imageSrc: "/imgs/projects/bloodborne-sudoku.gif",
+    imageAlt: "Bloodborne Sudoku gameplay screenshot",
+    githubUrl: "https://github.com/httpassoca/bloodborne-sudoku",
+    websiteUrl: "https://sudoku.passoca.dev",
+  },
+];

--- a/src/lib/data/svgs.ts
+++ b/src/lib/data/svgs.ts
@@ -20,6 +20,7 @@ export type SVGNames =
   | "photoshop"
   | "postgresql"
   | "react"
+  | "search"
   | "senai"
   | "socketio"
   | "spiry"
@@ -50,6 +51,19 @@ export const icons = [
     path: `
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
       <path stroke-linecap="round" stroke-linejoin="round" d="m10.5 21 5.25-11.25L21 21m-9-3h7.5M3 5.621a48.474 48.474 0 0 1 6-.371m0 0c1.12 0 2.233.038 3.334.114M9 5.25V3m3.334 2.364C11.176 10.658 7.69 15.08 3 17.502m9.334-12.138c.896.061 1.785.147 2.666.257m-4.589 8.495a18.023 18.023 0 0 1-3.827-5.802" />
+    </svg>
+    `,
+  },
+  {
+    name: "search",
+    viewBox: "0 0 24 24",
+    width: "1em",
+    height: "1em",
+    fill: "currentColor",
+    path: `
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+      <circle cx="11" cy="11" r="7" />
+      <path stroke-linecap="round" d="M16.5 16.5 21 21" />
     </svg>
     `,
   },

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -1,0 +1,169 @@
+// Search palette engine. This module is heavy — minisearch plus the raw
+// markdown of every post — and must only ever be loaded via dynamic
+// `import("$lib/search")` from the palette. The globs are eager so Vite
+// bundles all posts into this one lazy chunk instead of one request each.
+import MiniSearch from "minisearch";
+import { getSlug } from "$lib/helpers/helpers";
+import { getPosts, type Locale } from "$lib/posts";
+import { projects } from "$lib/data/projects";
+import { m } from "$lib/paraglide/messages";
+import { buildSnippet, fold, stripMarkdown, type SnippetPart } from "./text";
+
+const rawBodies: Record<Locale, Record<string, string>> = {
+  en: import.meta.glob("../blog/en/*.md", {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }) as Record<string, string>,
+  "pt-BR": import.meta.glob("../blog/pt-BR/*.md", {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }) as Record<string, string>,
+};
+
+export type SearchDocType = "page" | "post" | "project";
+
+export type SearchDoc = {
+  id: string;
+  type: SearchDocType;
+  title: string;
+  description: string;
+  body: string;
+  tags: string[];
+  /** Unlocalized path — pass through `localizeHref` at render/goto time. */
+  href: string;
+};
+
+/**
+ * What the palette renders: a matched doc plus a highlighted excerpt.
+ * Snippets are precomputed here so the palette never imports the text
+ * utilities into the always-loaded bundle.
+ */
+export type SearchResult = {
+  id: string;
+  type: SearchDocType;
+  title: string;
+  href: string;
+  snippet: SnippetPart[];
+};
+
+export type SearchApi = {
+  query: (q: string) => SearchResult[];
+  /** Static page docs, used as quick-jumps for the empty query. */
+  pages: SearchDoc[];
+};
+
+function buildPageDocs(locale: Locale): SearchDoc[] {
+  const opts = { locale };
+  const pages: { title: string; href: string }[] = [
+    { title: m.nav_home({}, opts), href: "/" },
+    { title: m.nav_career({}, opts), href: "/career" },
+    { title: m.nav_projects({}, opts), href: "/projects" },
+    { title: m.nav_blog({}, opts), href: "/blog" },
+    { title: m.nav_contact({}, opts), href: "/contact" },
+  ];
+  return pages.map((p) => ({
+    id: `page:${p.href}`,
+    type: "page" as const,
+    title: p.title,
+    description: "",
+    body: "",
+    tags: [],
+    href: p.href,
+  }));
+}
+
+function buildPostDocs(locale: Locale): SearchDoc[] {
+  // Metadata comes from getPosts() (already filters `hidden` and sorts);
+  // raw markdown is joined by slug so filtered posts are never indexed.
+  const bySlug: Record<string, string> = {};
+  for (const [filepath, raw] of Object.entries(rawBodies[locale])) {
+    bySlug[getSlug(filepath)] = raw;
+  }
+  return getPosts(locale).map((post) => ({
+    id: `post:${post.slug}`,
+    type: "post" as const,
+    title: post.title,
+    description: post.description ?? "",
+    body: stripMarkdown(bySlug[post.slug] ?? ""),
+    tags: post.tags ?? [],
+    href: `/blog/${post.slug}`,
+  }));
+}
+
+// Project content is English-only; indexed as-is in both locales.
+const projectDocs: SearchDoc[] = projects.map((p) => ({
+  id: `project:${p.name}`,
+  type: "project" as const,
+  title: p.name,
+  description: p.description,
+  body: p.features.join(". "),
+  tags: [],
+  href: "/projects",
+}));
+
+const POST_LIMIT = 8;
+const GROUP_ORDER: Record<SearchDocType, number> = {
+  page: 0,
+  post: 1,
+  project: 2,
+};
+
+const cache = new Map<Locale, SearchApi>();
+
+export function getSearch(locale: Locale): SearchApi {
+  const cached = cache.get(locale);
+  if (cached) return cached;
+
+  const docs = [
+    ...buildPageDocs(locale),
+    ...buildPostDocs(locale),
+    ...projectDocs,
+  ];
+
+  const mini = new MiniSearch<SearchDoc>({
+    fields: ["title", "tags", "description", "body"],
+    storeFields: ["type", "title", "description", "body", "tags", "href"],
+    extractField: (doc, field) =>
+      field === "tags" ? doc.tags.join(" ") : (doc as any)[field],
+    processTerm: (term) => fold(term),
+    searchOptions: {
+      boost: { title: 4, tags: 3, description: 2, body: 1 },
+      prefix: true,
+      fuzzy: 0.2,
+      combineWith: "AND",
+    },
+  });
+  mini.addAll(docs);
+
+  const api: SearchApi = {
+    pages: docs.filter((d) => d.type === "page"),
+    query(q: string): SearchResult[] {
+      const trimmed = q.trim();
+      if (!trimmed) return [];
+      const hits = mini.search(trimmed).map(
+        (hit): SearchResult => ({
+          id: hit.id,
+          type: hit.type,
+          title: hit.title,
+          href: hit.href,
+          snippet:
+            hit.type === "page"
+              ? []
+              : buildSnippet(hit.body, hit.terms, hit.description),
+        })
+      );
+      // Stable-group by type (pages → posts → projects), score order within.
+      const grouped = hits
+        .slice()
+        .sort((a, b) => GROUP_ORDER[a.type] - GROUP_ORDER[b.type]);
+      let posts = 0;
+      return grouped.filter((r) =>
+        r.type === "post" ? ++posts <= POST_LIMIT : true
+      );
+    },
+  };
+  cache.set(locale, api);
+  return api;
+}

--- a/src/lib/search/text.test.ts
+++ b/src/lib/search/text.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { buildSnippet, fold, stripMarkdown } from "./text";
+
+describe("stripMarkdown", () => {
+  it("removes YAML frontmatter", () => {
+    const raw = `---\ntitle: My post\ntags: [a, b]\n---\n\nHello world`;
+    expect(stripMarkdown(raw)).toBe("Hello world");
+  });
+
+  it("removes frontmatter with CRLF line endings", () => {
+    const raw = `---\r\ntitle: My post\r\n---\r\nHello`;
+    expect(stripMarkdown(raw)).toBe("Hello");
+  });
+
+  it("removes mdsvex script blocks", () => {
+    const raw = `---\ntitle: t\n---\n\n<script lang="ts">\n  import SVG from '$lib/x';\n  const a = 1 < 2;\n</script>\n\nActual content`;
+    expect(stripMarkdown(raw)).toBe("Actual content");
+  });
+
+  it("drops fenced code blocks but keeps inline code content", () => {
+    const raw =
+      "Before\n\n```js\nconst secret = 42;\n```\n\nUse `npm install` after";
+    const out = stripMarkdown(raw);
+    expect(out).not.toContain("secret");
+    expect(out).toContain("npm install");
+  });
+
+  it("converts links and images to their text", () => {
+    const raw = "See [the docs](https://example.com) and ![alt text](/img.png)";
+    expect(stripMarkdown(raw)).toBe("See the docs and alt text");
+  });
+
+  it("strips html tags, headings, lists and emphasis markers", () => {
+    const raw = `# Title\n\n> quote\n\n- item **bold** and _italic_\n\n<div class="x">inside</div>`;
+    const out = stripMarkdown(raw);
+    expect(out).toBe("Title quote item bold and italic inside");
+  });
+});
+
+describe("fold", () => {
+  it("lowercases and strips accents", () => {
+    expect(fold("MÚSICA")).toBe("musica");
+    expect(fold("ação")).toBe("acao");
+    expect(fold("Ela é você")).toBe("ela e voce");
+  });
+
+  it("leaves plain ascii untouched", () => {
+    expect(fold("hello")).toBe("hello");
+  });
+});
+
+describe("buildSnippet", () => {
+  const rejoin = (parts: { text: string }[]) =>
+    parts.map((p) => p.text).join("");
+  const hits = (parts: { text: string; hit: boolean }[]) =>
+    parts.filter((p) => p.hit).map((p) => p.text);
+
+  it("marks the matched term and windows around it", () => {
+    const body = "aaa ".repeat(50) + "the needle is here" + " bbb".repeat(50);
+    const parts = buildSnippet(body, ["needle"]);
+    expect(hits(parts)).toEqual(["needle"]);
+    const text = rejoin(parts);
+    expect(text.startsWith("…")).toBe(true);
+    expect(text.endsWith("…")).toBe(true);
+    expect(text.length).toBeLessThan(body.length);
+  });
+
+  it("highlights the accented original for an accent-less query", () => {
+    const body = "Eu adoro ouvir música brasileira todos os dias";
+    const parts = buildSnippet(body, ["musica"]);
+    expect(hits(parts)).toEqual(["música"]);
+    expect(rejoin(parts)).toContain("música brasileira");
+  });
+
+  it("survives regex-special queries", () => {
+    const body = "I learned c++ at school";
+    const parts = buildSnippet(body, ["c++"]);
+    expect(hits(parts)).toEqual(["c++"]);
+  });
+
+  it("marks every term occurrence inside the window", () => {
+    const body = "cats love cats and more cats";
+    const parts = buildSnippet(body, ["cats"]);
+    expect(hits(parts)).toEqual(["cats", "cats", "cats"]);
+  });
+
+  it("falls back to the description when no term matches the body", () => {
+    const parts = buildSnippet(
+      "body text without it",
+      ["zzz"],
+      "the description"
+    );
+    expect(parts).toEqual([{ text: "the description", hit: false }]);
+  });
+
+  it("falls back to the body head when there is no description either", () => {
+    const body = "word ".repeat(100);
+    const parts = buildSnippet(body, ["zzz"]);
+    expect(parts).toHaveLength(1);
+    expect(parts[0].hit).toBe(false);
+    expect(parts[0].text.length).toBeLessThanOrEqual(120);
+  });
+
+  it("returns nothing for an empty body and no fallback", () => {
+    expect(buildSnippet("", ["term"])).toEqual([]);
+  });
+});

--- a/src/lib/search/text.ts
+++ b/src/lib/search/text.ts
@@ -1,0 +1,133 @@
+// Pure text utilities for the search palette. Keep this module free of DOM,
+// `$app` and `$lib/paraglide` imports — it runs under the plugin-less vitest
+// config (node environment).
+
+/**
+ * Reduce a raw mdsvex/markdown source to plain prose for indexing and
+ * excerpts. Fenced code blocks are dropped entirely (noise in one-line
+ * excerpts); inline code keeps its content.
+ */
+export function stripMarkdown(raw: string): string {
+  let text = raw;
+
+  // YAML frontmatter
+  text = text.replace(/^---\r?\n[\s\S]*?\r?\n---\s*/, "");
+  // mdsvex component scripts
+  text = text.replace(/<script[\s\S]*?<\/script>/gi, "");
+  // <style> blocks, just in case a post carries one
+  text = text.replace(/<style[\s\S]*?<\/style>/gi, "");
+  // fenced code blocks
+  text = text.replace(/```[\s\S]*?```/g, " ");
+  // images -> alt text
+  text = text.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1");
+  // links -> link text
+  text = text.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1");
+  // residual HTML / Svelte tags
+  text = text.replace(/<[^>]+>/g, " ");
+  // table separator rows and pipes
+  text = text.replace(/^\s*\|?[\s:|-]+\|[\s:|-]*$/gm, " ");
+  text = text.replace(/\|/g, " ");
+  // heading markers, blockquotes, list markers
+  text = text.replace(/^\s{0,3}#{1,6}\s+/gm, "");
+  text = text.replace(/^\s{0,3}>\s?/gm, "");
+  text = text.replace(/^\s*(?:[-*+]|\d+\.)\s+/gm, "");
+  // emphasis / strikethrough / inline-code markers
+  text = text.replace(/(\*\*|__|[*_~`])/g, "");
+  // collapse whitespace
+  text = text.replace(/\s+/g, " ").trim();
+
+  return text;
+}
+
+/** Lowercase + strip combining accents ("música" -> "musica"). */
+export function fold(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "");
+}
+
+export type SnippetPart = { text: string; hit: boolean };
+
+const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Build a ~one-line excerpt of `body` around the first match of the longest
+ * term, with matched ranges marked `hit: true`.
+ *
+ * Matching happens on a folded (lowercased, accent-stripped) copy of the
+ * body. `fold` strips combining marks per code point, so an index into the
+ * folded string maps back to the same code-point index in the original —
+ * that's what lets an accent-less query highlight the accented original.
+ */
+export function buildSnippet(
+  body: string,
+  terms: string[],
+  fallback = "",
+  radius = 60
+): SnippetPart[] {
+  const chars = Array.from(body);
+  const foldedChars = chars.map((c) => fold(c));
+  const folded = foldedChars.join("");
+
+  // fold() can change a char's length (e.g. drops a combining mark, or "ﬁ"
+  // -> "fi"), so track each folded index back to its original char index.
+  const toOriginal: number[] = [];
+  for (let i = 0; i < foldedChars.length; i++) {
+    for (let j = 0; j < foldedChars[i].length; j++) toOriginal.push(i);
+  }
+
+  const cleaned = terms
+    .map((t) => fold(t.trim()))
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length);
+
+  const anchorTerm = cleaned.find((t) => folded.includes(t));
+  if (!anchorTerm) {
+    const text = fallback || chars.slice(0, 120).join("");
+    return text ? [{ text, hit: false }] : [];
+  }
+
+  // Window (in folded indices) around the anchor, expanded to word bounds.
+  const anchorStart = folded.indexOf(anchorTerm);
+  let winStart = Math.max(0, anchorStart - radius);
+  let winEnd = Math.min(
+    folded.length,
+    anchorStart + anchorTerm.length + radius
+  );
+  while (winStart > 0 && !/\s/.test(folded[winStart - 1])) winStart--;
+  while (winEnd < folded.length && !/\s/.test(folded[winEnd])) winEnd++;
+
+  // Collect hit ranges (folded indices) for every term inside the window.
+  const pattern = new RegExp(cleaned.map(escapeRegex).join("|"), "g");
+  const ranges: [number, number][] = [];
+  const windowText = folded.slice(winStart, winEnd);
+  for (const match of windowText.matchAll(pattern)) {
+    const start = winStart + (match.index ?? 0);
+    const end = start + match[0].length;
+    const last = ranges[ranges.length - 1];
+    if (last && start <= last[1]) last[1] = Math.max(last[1], end);
+    else ranges.push([start, end]);
+  }
+
+  // Map folded ranges back to the original string and assemble parts.
+  const orig = (foldedIdx: number) =>
+    foldedIdx >= toOriginal.length ? chars.length : toOriginal[foldedIdx];
+  const parts: SnippetPart[] = [];
+  const push = (from: number, to: number, hit: boolean) => {
+    const text = chars.slice(from, to).join("");
+    if (text) parts.push({ text, hit });
+  };
+
+  let cursor = orig(winStart);
+  if (winStart > 0) parts.push({ text: "…", hit: false });
+  for (const [start, end] of ranges) {
+    push(cursor, orig(start), false);
+    push(orig(start), orig(end), true);
+    cursor = orig(end);
+  }
+  push(cursor, orig(winEnd), false);
+  if (winEnd < folded.length) parts.push({ text: "…", hit: false });
+
+  return parts;
+}

--- a/src/lib/stores/search.store.ts
+++ b/src/lib/stores/search.store.ts
@@ -1,0 +1,7 @@
+import { writable } from "svelte/store";
+
+export const searchOpen = writable(false);
+
+export const openSearch = () => searchOpen.set(true);
+export const closeSearch = () => searchOpen.set(false);
+export const toggleSearch = () => searchOpen.update((open) => !open);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,16 +1,22 @@
 <script lang="ts">
   import { page } from "$app/stores";
-  import { BottomNav } from "dssoca";
+  import { BottomNav, registerIcon } from "dssoca";
+  import type { IconName } from "dssoca";
   import Header from "$lib/components/Header.svelte";
   import PageTransition from "$lib/components/PageTransition.svelte";
+  import SearchPalette from "$lib/components/SearchPalette.svelte";
   import { theme } from "$lib/stores/theme.store";
   import { viewportWidth } from "$lib/stores/window.store";
+  import { openSearch } from "$lib/stores/search.store";
   import { localizeHref } from "$lib/paraglide/runtime";
   import { m } from "$lib/paraglide/messages";
   import { onMount } from "svelte";
   import "dssoca/tokens.css";
   import "../app.css";
   import "../sass/global.sass";
+
+  // dssoca has no search builtin (DS icon set); register the glyph once
+  registerIcon("search", '<circle cx="11" cy="11" r="7"/><path d="M16.5 16.5L21 21"/>');
 
   onMount(() => {
     viewportWidth.set(window.innerWidth);
@@ -23,6 +29,7 @@
     { id: "career", label: m.nav_career(), icon: "briefcase" as const, href: localizeHref("/career") },
     { id: "projects", label: m.nav_projects(), icon: "folder" as const, href: localizeHref("/projects") },
     { id: "blog", label: m.nav_blog(), icon: "note" as const, href: localizeHref("/blog") },
+    { id: "search", label: m.nav_search(), icon: "search" as IconName },
   ];
   $: pathname = $page.url.pathname;
   $: activeNav =
@@ -62,8 +69,17 @@
       <slot />
     </PageTransition>
     {#if isMobile}
-      <BottomNav items={navItems} active={activeNav} ariaLabel="Mobile navigation" />
+      <BottomNav
+        items={navItems}
+        active={activeNav}
+        ariaLabel="Mobile navigation"
+        onSelect={(id) => {
+          // onSelect also fires for href tabs — only act on the search one
+          if (id === "search") openSearch();
+        }}
+      />
     {/if}
+    <SearchPalette />
   </main>
 {:else}
   <slot />

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -4,6 +4,7 @@
   import ProjectCard from "$lib/components/ProjectCard.svelte";
 
   import { icons } from "$lib/data/skills";
+  import { projects } from "$lib/data/projects";
   import { m } from "$lib/paraglide/messages";
 </script>
 
@@ -11,21 +12,9 @@
   <section class="projects">
     <Heading>Projects</Heading>
     <div class="projects-grid">
-      <ProjectCard
-        name="Bloodborne Sudoku"
-        description="A Bloodborne-themed Sudoku with a custom UI and game feel — built to be playable and polished on mobile. AI btw."
-        features={[
-          "Multiple difficulties + new puzzle generation",
-          "Notes/pencil marks + error highlighting",
-          "Keyboard support (desktop) + touch-first controls (mobile)",
-          "Bloodborne-inspired theme, typography and sound design",
-          "Multiplayer coop and duel modes",
-        ]}
-        imageSrc="/imgs/projects/bloodborne-sudoku.gif"
-        imageAlt="Bloodborne Sudoku gameplay screenshot"
-        githubUrl="https://github.com/httpassoca/bloodborne-sudoku"
-        websiteUrl="https://sudoku.passoca.dev"
-      />
+      {#each projects as project (project.name)}
+        <ProjectCard {...project} />
+      {/each}
     </div>
   </section>
 
@@ -45,6 +34,7 @@
   margin-top: 15px
   display: grid
   grid-template-columns: 1fr
+  grid-gap: 20px
 
 .grid-icons
   margin-top: 15px

--- a/yarn.lock
+++ b/yarn.lock
@@ -3378,6 +3378,11 @@ minipass@^7.0.4, minipass@^7.1.2:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
+minisearch@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/minisearch/-/minisearch-7.2.0.tgz#3dc30e41e9464b3836553b6d969b656614f8f359"
+  integrity sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==
+
 minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"


### PR DESCRIPTION
## Summary
- Global **Cmd+K / Ctrl+K command palette** searching blog posts (full-text), projects, and static pages, scoped to the active locale (en / pt-BR)
- Lazy-loaded search index: `minisearch` + raw markdown bodies live in a dynamically imported chunk, fetched only on first open
- Results show a matched excerpt with the query highlighted (accent-folded so pt-BR queries like "musica" match "música")
- Triggers: search button in the desktop Header, search item in the mobile BottomNav
- Projects extracted from hard-coded markup into `src/lib/data/projects.ts` (also adds the dssoca project card), shared by the page and the search index
- New i18n message keys for both locales

## Test plan
- [x] `vitest run` — 30 tests pass (15 new for markdown stripping / snippet building)
- [x] `svelte-check` — 0 errors (after paraglide compile of the new message keys)
- [x] Manual: Cmd+K open/close, arrow-key navigation, Enter navigates, Esc restores focus, mobile BottomNav trigger, pt-BR locale indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)